### PR TITLE
Support more auth endpoints

### DIFF
--- a/api/form.go
+++ b/api/form.go
@@ -20,7 +20,7 @@ type FormResponse struct {
 	requestURI string
 	values     url.Values
 
-	json map[string]string
+	json map[string]interface{}
 
 	contentType string
 }
@@ -31,7 +31,7 @@ func (f FormResponse) Get(k string) string {
 		return f.values.Get(k)
 	} else {
 		if v, ok := f.json[k]; ok {
-			return v
+			return v.(string)
 		}
 
 		return ""
@@ -97,7 +97,7 @@ func PostForm(c httpClient, u string, params url.Values) (*FormResponse, error) 
 			return r, err
 		}
 	} else if ct == jsonType {
-		jObj := make(map[string]string)
+		jObj := make(map[string]interface{})
 		err := json.Unmarshal(bb, &jObj)
 		r.json = jObj
 		if err != nil {

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
 github.com/cli/browser v1.0.0 h1:RIleZgXrhdiCVgFBSjtWwkLPUCWyhhhN5k5HGSBt1js=
 github.com/cli/browser v1.0.0/go.mod h1:IEWkHYbLjkhtjwwWlwTHW2lGxeS5gezEQBMLTwDHf5Q=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
 github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=


### PR DESCRIPTION
Hi, 

this is a draft to support other endpoints than GitHub.

In my specific case, I had to use Microsofts Auth Endpoint wich is a bit different than that from GitHub.
See details [here](https://docs.microsoft.com/de-de/graph/auth-v2-user).

I needed the support of additional post parameters in the AccessToken function and also to handle JSON based responses.

My solution is not that generic (to support others) as I wanted, because I had to focus on my specific case but maybe it is a good starting point for other auth endpoints.