### PR TITLE
Expose refresh token (used by GitHub Apps)

### DIFF
--- a/api/access_token.go
+++ b/api/access_token.go
@@ -4,6 +4,8 @@ package api
 type AccessToken struct {
 	// The token value, typically a 40-character random string.
 	Token string
+	// The refresh token value, associated with the access token.
+	RefreshToken string
 	// The token type, e.g. "bearer".
 	Type string
 	// Space-separated list of OAuth scopes that this token grants.
@@ -14,9 +16,10 @@ type AccessToken struct {
 func (f FormResponse) AccessToken() (*AccessToken, error) {
 	if accessToken := f.Get("access_token"); accessToken != "" {
 		return &AccessToken{
-			Token: accessToken,
-			Type:  f.Get("token_type"),
-			Scope: f.Get("scope"),
+			Token:        accessToken,
+			RefreshToken: f.Get("refresh_token"),
+			Type:         f.Get("token_type"),
+			Scope:        f.Get("scope"),
 		}, nil
 	}
 

--- a/api/access_token_test.go
+++ b/api/access_token_test.go
@@ -23,9 +23,28 @@ func TestFormResponse_AccessToken(t *testing.T) {
 				},
 			},
 			want: &AccessToken{
-				Token: "ATOKEN",
-				Type:  "bearer",
-				Scope: "repo gist",
+				Token:        "ATOKEN",
+				RefreshToken: "",
+				Type:         "bearer",
+				Scope:        "repo gist",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "with refresh token",
+			response: FormResponse{
+				values: url.Values{
+					"access_token":  []string{"ATOKEN"},
+					"refresh_token": []string{"AREFRESHTOKEN"},
+					"token_type":    []string{"bearer"},
+					"scope":         []string{"repo gist"},
+				},
+			},
+			want: &AccessToken{
+				Token:        "ATOKEN",
+				RefreshToken: "AREFRESHTOKEN",
+				Type:         "bearer",
+				Scope:        "repo gist",
 			},
 			wantErr: nil,
 		},


### PR DESCRIPTION
GitHub Apps have the ability to expose [refresh_tokens](https://developer.github.com/changes/2020-04-30-expiring-user-to-server-access-tokens-for-github-apps/) when [identifying and authorizing users](https://docs.github.com/en/developers/apps/building-github-apps/identifying-and-authorizing-users-for-github-apps) using either the device or web flow.

This refresh token is valid for 6 months and can be exchanged for a fresh access token (valid for 8 hours) and a new refresh token.

This PR exposes the `refresh_token` that is returned when using the OAuth flow with a GitHub App.