### PR TITLE
Support Google "OAuth 2.0 for TV and Limited-Input Device Applications"

### DIFF
--- a/device/device_flow.go
+++ b/device/device_flow.go
@@ -51,9 +51,6 @@ type CodeResponse struct {
 	// The minimum number of seconds that must pass before you can make a new access token request to
 	// complete the device authorization.
 	Interval int
-
-	timeNow   func() time.Time
-	timeSleep func(time.Duration)
 }
 
 // RequestCode initiates the authorization flow by requesting a code from uri.
@@ -102,37 +99,66 @@ func RequestCode(c httpClient, uri string, clientID string, scopes []string) (*C
 	}, nil
 }
 
-const grantType = "urn:ietf:params:oauth:grant-type:device_code"
+const defaultGrantType = "urn:ietf:params:oauth:grant-type:device_code"
 
 // PollToken polls the server at pollURL until an access token is granted or denied.
-func PollToken(c httpClient, pollURL string, clientID string, clientSecret *string, code *CodeResponse) (*api.AccessToken, error) {
-	timeNow := code.timeNow
+//
+// Deprecated: use PollTokenWithOptions.
+func PollToken(c httpClient, pollURL string, clientID string, code *CodeResponse) (*api.AccessToken, error) {
+	return PollTokenWithOptions(c, pollURL, PollOptions{
+		ClientID:   clientID,
+		DeviceCode: code,
+	})
+}
+
+// PollOptions specifies parameters to poll the server with until authentication completes.
+type PollOptions struct {
+	// ClientID is the app client ID value.
+	ClientID string
+	// ClientSecret is the app client secret value. Optional: only pass if the server requires it.
+	ClientSecret string
+	// DeviceCode is the value obtained from RequestCode.
+	DeviceCode *CodeResponse
+	// GrantType overrides the default value specified by OAuth 2.0 Device Code. Optional.
+	GrantType string
+
+	timeNow   func() time.Time
+	timeSleep func(time.Duration)
+}
+
+// PollTokenWithOptions polls the server at uri until authorization completes.
+func PollTokenWithOptions(c httpClient, uri string, opts PollOptions) (*api.AccessToken, error) {
+	timeNow := opts.timeNow
 	if timeNow == nil {
 		timeNow = time.Now
 	}
-	timeSleep := code.timeSleep
+	timeSleep := opts.timeSleep
 	if timeSleep == nil {
 		timeSleep = time.Sleep
 	}
 
-	checkInterval := time.Duration(code.Interval) * time.Second
-	expiresAt := timeNow().Add(time.Duration(code.ExpiresIn) * time.Second)
+	checkInterval := time.Duration(opts.DeviceCode.Interval) * time.Second
+	expiresAt := timeNow().Add(time.Duration(opts.DeviceCode.ExpiresIn) * time.Second)
+	grantType := opts.GrantType
+	if opts.GrantType == "" {
+		grantType = defaultGrantType
+	}
 
 	for {
 		timeSleep(checkInterval)
 
 		values := url.Values{
-			"client_id":   {clientID},
-			"device_code": {code.DeviceCode},
+			"client_id":   {opts.ClientID},
+			"device_code": {opts.DeviceCode.DeviceCode},
 			"grant_type":  {grantType},
 		}
 
 		// Google's "OAuth 2.0 for TV and Limited-Input Device Applications" requires `client_secret`.
-		if clientSecret != nil {
-			values.Add("client_secret", *clientSecret)
+		if opts.ClientSecret != "" {
+			values.Add("client_secret", opts.ClientSecret)
 		}
 
-		resp, err := api.PostForm(c, pollURL, values)
+		resp, err := api.PostForm(c, uri, values)
 		if err != nil {
 			return nil, err
 		}

--- a/device/device_flow_test.go
+++ b/device/device_flow_test.go
@@ -371,7 +371,7 @@ func TestPollToken(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			totalSlept = 0
-			got, err := PollToken(&tt.args.http, tt.args.url, tt.args.clientID, tt.args.code)
+			got, err := PollToken(&tt.args.http, tt.args.url, tt.args.clientID, nil, tt.args.code)
 			if (err != nil) != (tt.wantErr != "") {
 				t.Errorf("PollToken() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/device/examples_test.go
+++ b/device/examples_test.go
@@ -22,7 +22,10 @@ func Example() {
 	fmt.Printf("Copy code: %s\n", code.UserCode)
 	fmt.Printf("then open: %s\n", code.VerificationURI)
 
-	accessToken, err := PollToken(httpClient, "https://github.com/login/oauth/access_token", clientID, nil, code)
+	accessToken, err := PollTokenWithOptions(httpClient, "https://github.com/login/oauth/access_token", PollOptions{
+		ClientID:   clientID,
+		DeviceCode: code,
+	})
 	if err != nil {
 		panic(err)
 	}

--- a/device/examples_test.go
+++ b/device/examples_test.go
@@ -22,7 +22,7 @@ func Example() {
 	fmt.Printf("Copy code: %s\n", code.UserCode)
 	fmt.Printf("then open: %s\n", code.VerificationURI)
 
-	accessToken, err := PollToken(httpClient, "https://github.com/login/oauth/access_token", clientID, code)
+	accessToken, err := PollToken(httpClient, "https://github.com/login/oauth/access_token", clientID, nil, code)
 	if err != nil {
 		panic(err)
 	}

--- a/oauth_device.go
+++ b/oauth_device.go
@@ -58,7 +58,10 @@ func (oa *Flow) DeviceFlow() (*api.AccessToken, error) {
 		return nil, fmt.Errorf("error opening the web browser: %w", err)
 	}
 
-	return device.PollToken(httpClient, host.TokenURL, oa.ClientID, nil, code)
+	return device.PollTokenWithOptions(httpClient, host.TokenURL, device.PollOptions{
+		ClientID:   oa.ClientID,
+		DeviceCode: code,
+	})
 }
 
 func waitForEnter(r io.Reader) error {

--- a/oauth_device.go
+++ b/oauth_device.go
@@ -58,7 +58,7 @@ func (oa *Flow) DeviceFlow() (*api.AccessToken, error) {
 		return nil, fmt.Errorf("error opening the web browser: %w", err)
 	}
 
-	return device.PollToken(httpClient, host.TokenURL, oa.ClientID, code)
+	return device.PollToken(httpClient, host.TokenURL, oa.ClientID, nil, code)
 }
 
 func waitForEnter(r io.Reader) error {


### PR DESCRIPTION
With some minor changes, this library can be made to work with Google's "[OAuth 2.0 for TV and Limited-Input Device Applications](https://developers.google.com/identity/protocols/oauth2/limited-input-device)". There are just two small changes to make:

* Google returns a `verification_url` instead of `verification_uri`, and
* Google requires the `client_secret` when polling for tokens.

**Example authentication**

```
Copy code: QCP-GZV-LGZ
then open: https://www.google.com/device
Access token: $ACCESS_TOKEN
```

<img src="https://user-images.githubusercontent.com/359154/160241083-91ad5585-d863-47fc-ab3e-3e551c82613d.png" width="50%" />
