### PR TITLE
create new func  to avoid the bug on issue #61

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -1,10 +1,10 @@
 package oauth_test
 
 import (
-	"fmt"
-	"os"
+  "fmt"
+  "os"
 
-	"github.com/cli/oauth"
+  "github.com/cli/oauth"
 )
 
 // DetectFlow attempts to initiate OAuth Device flow with the server and falls back to OAuth Web
@@ -12,18 +12,19 @@ import (
 // github.com, as its Device flow support is globally available, but it enables logging in to
 // self-hosted GitHub instances as well.
 func ExampleFlow_DetectFlow() {
-	flow := &oauth.Flow{
-		Host:         oauth.GitHubHost("https://github.com"),
-		ClientID:     os.Getenv("OAUTH_CLIENT_ID"),
-		ClientSecret: os.Getenv("OAUTH_CLIENT_SECRET"), // only applicable to web app flow
-		CallbackURI:  "http://127.0.0.1/callback",      // only applicable to web app flow
-		Scopes:       []string{"repo", "read:org", "gist"},
-	}
+  host, err := oauth.NewGitHubHost("https://github.com")
+  flow := &oauth.Flow{
+    Host:         host,
+    ClientID:     os.Getenv("OAUTH_CLIENT_ID"),
+    ClientSecret: os.Getenv("OAUTH_CLIENT_SECRET"), // only applicable to web app flow
+    CallbackURI:  "http://127.0.0.1/callback",      // only applicable to web app flow
+    Scopes:       []string{"repo", "read:org", "gist"},
+  }
 
-	accessToken, err := flow.DetectFlow()
-	if err != nil {
-		panic(err)
-	}
+  accessToken, err := flow.DetectFlow()
+  if err != nil {
+    panic(err)
+  }
 
-	fmt.Printf("Access token: %s\n", accessToken.Token)
+  fmt.Printf("Access token: %s\n", accessToken.Token)
 }

--- a/oauth.go
+++ b/oauth.go
@@ -3,77 +3,91 @@
 package oauth
 
 import (
-	"errors"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
+  "errors"
+  "fmt"
+  "io"
+  "net/http"
+  "net/url"
+  "strings"
 
-	"github.com/cli/oauth/api"
-	"github.com/cli/oauth/device"
+  "github.com/cli/oauth/api"
+  "github.com/cli/oauth/device"
 )
 
 type httpClient interface {
-	PostForm(string, url.Values) (*http.Response, error)
+  PostForm(string, url.Values) (*http.Response, error)
 }
 
 // Host defines the endpoints used to authorize against an OAuth server.
 type Host struct {
-	DeviceCodeURL string
-	AuthorizeURL  string
-	TokenURL      string
+  DeviceCodeURL string
+  AuthorizeURL  string
+  TokenURL      string
+}
+
+func NewGitHubHost(hostURL string) (*Host, error) {
+  u, err := url.Parse(strings.TrimSpace(hostURL))
+  if err != nil {
+    return nil, err
+  }
+
+  return &Host{
+    DeviceCodeURL: fmt.Sprintf("%s://%s/login/device/code", u.Scheme, u.Host),
+    AuthorizeURL:  fmt.Sprintf("%s://%s/login/oauth/authorize", u.Scheme, u.Host),
+    TokenURL:      fmt.Sprintf("%s://%s/login/oauth/access_token", u.Scheme, u.Host),
+  }, nil
 }
 
 // GitHubHost constructs a Host from the given URL to a GitHub instance.
 func GitHubHost(hostURL string) *Host {
-	u, _ := url.Parse(hostURL)
+  u, _ := url.Parse(hostURL)
 
-	return &Host{
-		DeviceCodeURL: fmt.Sprintf("%s://%s/login/device/code", u.Scheme, u.Host),
-		AuthorizeURL:  fmt.Sprintf("%s://%s/login/oauth/authorize", u.Scheme, u.Host),
-		TokenURL:      fmt.Sprintf("%s://%s/login/oauth/access_token", u.Scheme, u.Host),
-	}
+  return &Host{
+    DeviceCodeURL: fmt.Sprintf("%s://%s/login/device/code", u.Scheme, u.Host),
+    AuthorizeURL:  fmt.Sprintf("%s://%s/login/oauth/authorize", u.Scheme, u.Host),
+    TokenURL:      fmt.Sprintf("%s://%s/login/oauth/access_token", u.Scheme, u.Host),
+  }
 }
 
 // Flow facilitates a single OAuth authorization flow.
 type Flow struct {
-	// The hostname to authorize the app with.
-	//
-	// Deprecated: Use Host instead.
-	Hostname string
-	// Host configuration to authorize the app with.
-	Host *Host
-	// OAuth scopes to request from the user.
-	Scopes []string
-	// OAuth application ID.
-	ClientID string
-	// OAuth application secret. Only applicable in web application flow.
-	ClientSecret string
-	// The localhost URI for web application flow callback, e.g. "http://127.0.0.1/callback".
-	CallbackURI string
+  // The hostname to authorize the app with.
+  //
+  // Deprecated: Use Host instead.
+  Hostname string
+  // Host configuration to authorize the app with.
+  Host *Host
+  // OAuth scopes to request from the user.
+  Scopes []string
+  // OAuth application ID.
+  ClientID string
+  // OAuth application secret. Only applicable in web application flow.
+  ClientSecret string
+  // The localhost URI for web application flow callback, e.g. "http://127.0.0.1/callback".
+  CallbackURI string
 
-	// Display a one-time code to the user. Receives the code and the browser URL as arguments. Defaults to printing the
-	// code to the user on Stdout with instructions to copy the code and to press Enter to continue in their browser.
-	DisplayCode func(string, string) error
-	// Open a web browser at a URL. Defaults to opening the default system browser.
-	BrowseURL func(string) error
-	// Render an HTML page to the user upon completion of web application flow. The default is to
-	// render a simple message that informs the user they can close the browser tab and return to the app.
-	WriteSuccessHTML func(io.Writer)
+  // Display a one-time code to the user. Receives the code and the browser URL as arguments. Defaults to printing the
+  // code to the user on Stdout with instructions to copy the code and to press Enter to continue in their browser.
+  DisplayCode func(string, string) error
+  // Open a web browser at a URL. Defaults to opening the default system browser.
+  BrowseURL func(string) error
+  // Render an HTML page to the user upon completion of web application flow. The default is to
+  // render a simple message that informs the user they can close the browser tab and return to the app.
+  WriteSuccessHTML func(io.Writer)
 
-	// The HTTP client to use for API POST requests. Defaults to http.DefaultClient.
-	HTTPClient httpClient
-	// The stream to listen to keyboard input on. Defaults to os.Stdin.
-	Stdin io.Reader
-	// The stream to print UI messages to. Defaults to os.Stdout.
-	Stdout io.Writer
+  // The HTTP client to use for API POST requests. Defaults to http.DefaultClient.
+  HTTPClient httpClient
+  // The stream to listen to keyboard input on. Defaults to os.Stdin.
+  Stdin io.Reader
+  // The stream to print UI messages to. Defaults to os.Stdout.
+  Stdout io.Writer
 }
 
 // DetectFlow tries to perform Device flow first and falls back to Web application flow.
 func (oa *Flow) DetectFlow() (*api.AccessToken, error) {
-	accessToken, err := oa.DeviceFlow()
-	if errors.Is(err, device.ErrUnsupported) {
-		return oa.WebAppFlow()
-	}
-	return accessToken, err
+  accessToken, err := oa.DeviceFlow()
+  if errors.Is(err, device.ErrUnsupported) {
+    return oa.WebAppFlow()
+  }
+  return accessToken, err
 }

--- a/oauth_device.go
+++ b/oauth_device.go
@@ -29,9 +29,15 @@ func (oa *Flow) DeviceFlow() (*api.AccessToken, error) {
 	if stdout == nil {
 		stdout = os.Stdout
 	}
+
 	host := oa.Host
 	if host == nil {
-		host = GitHubHost("https://" + oa.Hostname)
+		_, err := NewGitHubHost("https://" + oa.Hostname)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing the hostname %w", err)
+		}
+
+		//host = GitHubHost("https://" + oa.Hostname)
 	}
 
 	code, err := device.RequestCode(httpClient, host.DeviceCodeURL, oa.ClientID, oa.Scopes)

--- a/oauth_webapp.go
+++ b/oauth_webapp.go
@@ -14,8 +14,13 @@ import (
 // flow, blocks until the user completes authorization and is redirected back, and returns the access token.
 func (oa *Flow) WebAppFlow() (*api.AccessToken, error) {
 	host := oa.Host
+
 	if host == nil {
-		host = GitHubHost("https://" + oa.Hostname)
+		_, err := NewGitHubHost("https://" + oa.Hostname)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing the hostname %w", err)
+		}
+		//host = GitHubHost("https://" + oa.Hostname)
 	}
 
 	flow, err := webapp.InitFlow()


### PR DESCRIPTION
This pull request primarily focuses on improving error handling and code readability in the OAuth flow. The changes include the introduction of a new function `NewGitHubHost` in `oauth.go` to parse the host URL and return an error if parsing fails. This function is then used in the files `examples_test.go`, `oauth_device.go`, and `oauth_webapp.go` to replace the previous method of creating a new host, improving error handling in the process.