### PR TITLE
feat: Add support for audience in authorization request

### DIFF
--- a/device/device_flow.go
+++ b/device/device_flow.go
@@ -54,9 +54,10 @@ type CodeResponse struct {
 	Interval int
 }
 
-// Function signature for setting additional form values.
+// AuthRequestEditorFn defines the function signature for setting additional form values.
 type AuthRequestEditorFn func(*url.Values)
 
+// WithAudience sets the audience parameter in the request.
 func WithAudience(audience string) AuthRequestEditorFn {
 	return func(values *url.Values) {
 		if audience != "" {

--- a/device/device_flow.go
+++ b/device/device_flow.go
@@ -55,9 +55,9 @@ type CodeResponse struct {
 }
 
 // Function signature for setting additional form values.
-type AuthRequestFn func(*url.Values)
+type AuthRequestEditorFn func(*url.Values)
 
-func WithAudience(audience string) AuthRequestFn {
+func WithAudience(audience string) AuthRequestEditorFn {
 	return func(values *url.Values) {
 		if audience != "" {
 			values.Add("audience", audience)
@@ -66,13 +66,14 @@ func WithAudience(audience string) AuthRequestFn {
 }
 
 // RequestCode initiates the authorization flow by requesting a code from uri.
-func RequestCode(c httpClient, uri string, clientID string, scopes []string, extra ...AuthRequestFn) (*CodeResponse, error) {
+func RequestCode(c httpClient, uri string, clientID string, scopes []string,
+	optionalRequestParams ...AuthRequestEditorFn) (*CodeResponse, error) {
 	values := url.Values{
 		"client_id": {clientID},
 		"scope":     {strings.Join(scopes, " ")},
 	}
 
-	for _, fn := range extra {
+	for _, fn := range optionalRequestParams {
 		fn(&values)
 	}
 

--- a/oauth.go
+++ b/oauth.go
@@ -45,6 +45,8 @@ type Flow struct {
 	Host *Host
 	// OAuth scopes to request from the user.
 	Scopes []string
+	// OAuth audience to request from the user.
+	Audience string
 	// OAuth application ID.
 	ClientID string
 	// OAuth application secret. Only applicable in web application flow.

--- a/oauth_device.go
+++ b/oauth_device.go
@@ -34,7 +34,8 @@ func (oa *Flow) DeviceFlow() (*api.AccessToken, error) {
 		host = GitHubHost("https://" + oa.Hostname)
 	}
 
-	code, err := device.RequestCode(httpClient, host.DeviceCodeURL, oa.ClientID, oa.Scopes)
+	code, err := device.RequestCode(httpClient, host.DeviceCodeURL,
+		oa.ClientID, oa.Scopes, device.WithAudience(oa.Audience))
 	if err != nil {
 		return nil, err
 	}

--- a/oauth_webapp.go
+++ b/oauth_webapp.go
@@ -27,6 +27,7 @@ func (oa *Flow) WebAppFlow() (*api.AccessToken, error) {
 		ClientID:    oa.ClientID,
 		RedirectURI: oa.CallbackURI,
 		Scopes:      oa.Scopes,
+		Audience:    oa.Audience,
 		AllowSignup: true,
 	}
 	browserURL, err := flow.BrowserURL(host.AuthorizeURL, params)

--- a/webapp/webapp_flow.go
+++ b/webapp/webapp_flow.go
@@ -47,6 +47,7 @@ type BrowserParams struct {
 	ClientID    string
 	RedirectURI string
 	Scopes      []string
+	Audience    string
 	LoginHandle string
 	AllowSignup bool
 }
@@ -68,6 +69,10 @@ func (flow *Flow) BrowserURL(baseURL string, params BrowserParams) (string, erro
 	q.Set("redirect_uri", ru.String())
 	q.Set("scope", strings.Join(params.Scopes, " "))
 	q.Set("state", flow.state)
+
+	if params.Audience != "" {
+		q.Set("audience", params.Audience)
+	}
 	if params.LoginHandle != "" {
 		q.Set("login", params.LoginHandle)
 	}

--- a/webapp/webapp_flow_test.go
+++ b/webapp/webapp_flow_test.go
@@ -51,6 +51,24 @@ func TestFlow_BrowserURL(t *testing.T) {
 			want:    "https://github.com/authorize?client_id=CLIENT-ID&redirect_uri=http%3A%2F%2F127.0.0.1%3A12345%2Fhello&scope=repo+read%3Aorg&state=xy%2Fz",
 			wantErr: false,
 		},
+		{
+			name: "happy path with audience",
+			fields: fields{
+				server: server,
+				state:  "xy/z",
+			},
+			args: args{
+				baseURL: "https://github.com/authorize",
+				params: BrowserParams{
+					ClientID:    "CLIENT-ID",
+					RedirectURI: "http://127.0.0.1/hello",
+					Scopes:      []string{"repo", "read:org"},
+					AllowSignup: true,
+					Audience:    "https://api.github.com",
+				},
+			},
+			want: "https://github.com/authorize?audience=https%3A%2F%2Fapi.github.com&client_id=CLIENT-ID&redirect_uri=http%3A%2F%2F127.0.0.1%3A12345%2Fhello&scope=repo+read%3Aorg&state=xy%2Fz",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Add support for `audience` in authorization request. This is required for IDPs that mandate having an audience field to be able to issue JWT in access token.