### PR TITLE
Include expiry fields

### DIFF
--- a/api/access_token.go
+++ b/api/access_token.go
@@ -1,11 +1,19 @@
 package api
 
+import (
+	"strconv"
+)
+
 // AccessToken is an OAuth access token.
 type AccessToken struct {
 	// The token value, typically a 40-character random string.
 	Token string
+	// Number of seconds until the access token expires.
+	ExpiresIn int
 	// The refresh token value, associated with the access token.
 	RefreshToken string
+	// Number of seconds until the refresh token expires.
+	RefreshTokenExpiresIn int
 	// The token type, e.g. "bearer".
 	Type string
 	// Space-separated list of OAuth scopes that this token grants.
@@ -15,11 +23,17 @@ type AccessToken struct {
 // AccessToken extracts the access token information from a server response.
 func (f FormResponse) AccessToken() (*AccessToken, error) {
 	if accessToken := f.Get("access_token"); accessToken != "" {
+		// Default to 0 if the expiry fields aren't present.
+		expiresIn, _ := strconv.Atoi(f.Get("expires_in"))
+		refreshTokenExpiresIn, _ := strconv.Atoi(f.Get("refresh_token_expires_in"))
+
 		return &AccessToken{
-			Token:        accessToken,
-			RefreshToken: f.Get("refresh_token"),
-			Type:         f.Get("token_type"),
-			Scope:        f.Get("scope"),
+			Token:                 accessToken,
+			ExpiresIn:             expiresIn,
+			RefreshToken:          f.Get("refresh_token"),
+			RefreshTokenExpiresIn: refreshTokenExpiresIn,
+			Type:                  f.Get("token_type"),
+			Scope:                 f.Get("scope"),
 		}, nil
 	}
 


### PR DESCRIPTION
During the [Github App User OAuth flow](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app#using-the-web-application-flow-to-generate-a-user-access-token), the `expires_in` and `refresh_token_expires_in` fields are included in the successful response to indicate how long the access token and refresh token are live for. I'm building a tool and need access to these fields, so it seems to be appropriate to return them along with the token and refresh token.