### PR TITLE
Adds a new section in README to guide developers on handling OAuth Client IDs and secrets in CLI/headless apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,22 @@ Applications that need more control over the user experience around authenticati
 
 In theory, these packages would enable authorization on any OAuth-enabled host. In practice, however, this was only tested for authorizing with GitHub.
 
+## Managing OAuth Client Identifier
+
+CLIs or headless applications using [device flow][gh-device] are considered [public clients][rfc-client-types]:
+
+> _Clients incapable of maintaining the confidentiality of their credentials (e.g., clients executing on the device used by the resource owner, such as an installed native application or a web browser-based application), and incapable of secure client authentication via any other means._
+
+For this reason, the GitHub CLI has its OAuth client information committed to `cli/cli` source code as:
+
+1. `gh` releases are publicly distributed and can be decompiled to retrieve this information
+2. `gh` has semi-officially supported `go install` installation as described in [cli/cli#9912](https://github.com/cli/cli/issues/9912)
+
+Applications using [web application flow][gh-web] must keep the OAuth client secret confidential.
+
+For more information, see [cli/oauth#1](https://github.com/cli/oauth/issues/1)
 
 [oauth-device]: https://oauth.net/2/device-flow/
 [gh-device]: https://docs.github.com/en/free-pro-team@latest/developers/apps/authorizing-oauth-apps#device-flow
-
-## OAuth Guidance for CLI and Headless Apps
-
-When building CLI or headless applications, it's acceptable to embed your OAuth **Client ID** and even the **Client Secret**, if needed. These values are easily extractable from compiled binaries, and thus can't be treated as secure. This is expected in public client scenarios - GitHub CLI does the same.
-
-OAuth secrets were originally designed for secure server-side applications. In contrast, client-side apps cannot protect secrets and should instead rely on trusted authorization flows like the **Device Authorization Flow**, which avoids requiring a secret entirely.
-
-While the Client ID could be reused by others, this poses minimal risk in practice. To reduce potential misuse, services can apply rate limiting, restrict scopes, and monitor usage tied to the client.
-
-🔗 [GitHub OAuth Device Flow Documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow)
+[gh-web]: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow
+[rfc-client-types]: https://datatracker.ietf.org/doc/html/rfc6749#section-2.1

--- a/README.md
+++ b/README.md
@@ -26,3 +26,13 @@ In theory, these packages would enable authorization on any OAuth-enabled host. 
 
 [oauth-device]: https://oauth.net/2/device-flow/
 [gh-device]: https://docs.github.com/en/free-pro-team@latest/developers/apps/authorizing-oauth-apps#device-flow
+
+## OAuth Guidance for CLI and Headless Apps
+
+When building CLI or headless applications, it's acceptable to embed your OAuth **Client ID** and even the **Client Secret**, if needed. These values are easily extractable from compiled binaries, and thus can't be treated as secure. This is expected in public client scenarios - GitHub CLI does the same.
+
+OAuth secrets were originally designed for secure server-side applications. In contrast, client-side apps cannot protect secrets and should instead rely on trusted authorization flows like the **Device Authorization Flow**, which avoids requiring a secret entirely.
+
+While the Client ID could be reused by others, this poses minimal risk in practice. To reduce potential misuse, services can apply rate limiting, restrict scopes, and monitor usage tied to the client.
+
+🔗 [GitHub OAuth Device Flow Documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ CLIs or headless applications using [device flow][gh-device] are considered [pub
 
 For this reason, the GitHub CLI has its OAuth client information committed to `cli/cli` source code as:
 
-1. `gh` releases are publicly distributed and can be decompiled to retrieve this information
+1. `gh` releases are publicly distributed and can be decompiled to retrieve this information as described in [cli/cli#492](https://github.com/cli/cli/pull/492)
 2. `gh` has semi-officially supported `go install` installation as described in [cli/cli#9912](https://github.com/cli/cli/issues/9912)
 
 Applications using [web application flow][gh-web] must keep the OAuth client secret confidential.


### PR DESCRIPTION
Fixes #1

## 📄 Summary

This PR adds a new section to the `README.md` titled **"OAuth Guidance for CLI and Headless Apps"**, providing clear guidance on handling OAuth Client ID and Secret in public clients such as CLI tools.

It incorporates recommendations made by maintainers in [Issue #1](https://github.com/cli/oauth/issues/1), highlighting:
- Why embedding secrets in public clients is acceptable
- The limitations of protecting secrets in client-side binaries
- The preferred use of GitHub's Device Flow for CLI authorization
- Basic mitigation techniques like rate limiting and usage monitoring

---

## 📝 Changes

- 📘 Added a new section to `README.md` with practical guidance for OAuth in public clients
- 🔗 Linked to GitHub's official Device Flow documentation
- 🧠 Incorporated insights from @mislav and GitHub CLI patterns

---

## 🔍 Related Issues

Fixes or completes: [#1](https://github.com/cli/oauth/issues/1)

---

## ✅ Checklist

- [x] Follows repo formatting and section style
- [x] Reflects official maintainer guidance
- [x] Improves clarity for CLI tool developers
- [x] No breaking changes introduced

---

## 🙋‍♂️ Notes for Reviewers

The goal here is to formalize guidance that was already shared in Issue #1 but never documented. Feedback welcome on tone or placement within the README.
