### PR TITLE
read GH_OAUTH_PORT from the environmnent to listen on a predictable port

### DIFF
--- a/webapp/local_server.go
+++ b/webapp/local_server.go
@@ -13,10 +13,9 @@ type CodeResponse struct {
 	Code  string
 	State string
 }
-
-// bindLocalServer initializes a LocalServer that will listen on a randomly available TCP port.
-func bindLocalServer() (*localServer, error) {
-	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+func bindLocalServerWithPort(port int) (*localServer, error) {
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	listener, err := net.Listen("tcp4", addr)
 	if err != nil {
 		return nil, err
 	}
@@ -25,6 +24,12 @@ func bindLocalServer() (*localServer, error) {
 		listener:   listener,
 		resultChan: make(chan CodeResponse, 1),
 	}, nil
+}
+
+// bindLocalServer initializes a LocalServer that will listen on a randomly available TCP port.
+func bindLocalServer() (*localServer, error) {
+	return bindLocalServerWithPort(0)
+
 }
 
 type localServer struct {

--- a/webapp/webapp_flow.go
+++ b/webapp/webapp_flow.go
@@ -11,8 +11,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
-
+	"strconv"
 	"github.com/cli/oauth/api"
 )
 
@@ -29,7 +30,20 @@ type Flow struct {
 
 // InitFlow creates a new Flow instance by detecting a locally available port number.
 func InitFlow() (*Flow, error) {
-	server, err := bindLocalServer()
+	
+	portStr := os.Getenv("GH_OAUTH_PORT")
+	port := 0
+
+
+	if portStr != "" {
+		var err error
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			port = 0
+		}
+	}
+	
+	server, err := bindLocalServerWithPort(port)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
auto-responding to #105  to add the redirect port from the oauth interactive flow to a predictable port so that port forwarding from vscode to the remote box (or WSL) can be setup before the authentication happens.

1) set GH_OAUTH_PORT to the desired port
2) setup port forwarding in your IDE to from the localhost to the remote box with the same port number
3) use gh auth login for the desired account , gh will generate the oauth login url including the encoded redirecturi  to the http://localhost:PORT

this is tentative with minimal code change to avoid propagating an option from the cli.