### PR TITLE
Avoid persisting credentials in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 on: [push, pull_request]
 
 name: CI
+
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -14,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ on:
       - go.mod
       - go.sum
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -23,6 +26,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Verify dependencies
         env:


### PR DESCRIPTION
Addresses zizmor findings in `.github/workflows/ci.yml` and `.github/workflows/lint.yml`.

## Changes

- Add top-level `permissions: contents: read` to both workflows (resolves `excessive-permissions`). Both are read-only CI jobs (`go test` / `golangci-lint`) and don't need any write scope on the repo.
- Add `persist-credentials: false` to the `actions/checkout` step in both workflows (resolves `artipacked`). Neither job uses the git credential after checkout, so dropping it is safe.

## Verification

Before:

```
9 findings (5 suppressed, 2 unsafe fixes): 0 informational, 0 low, 4 medium, 0 high
```

After:

```
No findings to report. Good job! (3 suppressed)
```

## Follow-up

A separate PR will bump the action versions (`actions/checkout@v2` → v5, `actions/setup-go@v3` → v6) and the Go version pinned for the linter job.