### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in this repo.
+# See: https://docs.github.com/articles/about-code-owners
+*       @cli/code-reviewers


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` file with `@cli/code-reviewers` as the default owner for the whole repo, mirroring the convention used in [`cli/cli`](https://github.com/cli/cli/blob/trunk/.github/CODEOWNERS).

Once merged, PRs against this repo will automatically request a review from the team.