### PR TITLE
Add Dependabot config with 5-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 5
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - version-update:semver-major
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 5


### PR DESCRIPTION
Adds `.github/dependabot.yml` mirroring the [cli/cli configuration](https://github.com/cli/cli/blob/trunk/.github/dependabot.yml):

- `gomod`, daily, ignore major-version updates
- `github-actions`, daily

…with one addition: a 5-day `cooldown.default-days` on both ecosystems so newly released versions have time to bake before Dependabot opens a PR for them.

See [Dependabot `cooldown` reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--).