### PR TITLE
Trim Go test matrix to latest 3 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: [ '1.21', '1.22', '1.23', '1.24', '1.25' ]
+        go: [ '1.24', '1.25', '1.26' ]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
       fail-fast: false
 


### PR DESCRIPTION
Drops older Go versions from the CI test matrix, keeping the latest three stable releases (1.24, 1.25, 1.26).

Five Go versions × three OSes was 15 jobs per CI run, which is more coverage than this small library needs. Testing against the last three Go releases matches the project's general support window and keeps CI duration / runner usage in check.