### PR TITLE
Bump golangci lint and fix issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,26 +19,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.19
-        uses: actions/setup-go@v6
-        with:
-          go-version: 1.19
-
       - name: Check out code
         uses: actions/checkout@v6
         with:
           persist-credentials: false
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+
       - name: Verify dependencies
-        env:
-          LINT_VERSION: 1.50.1
         run: |
           go mod verify
           go mod download
 
-          curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v${LINT_VERSION}/golangci-lint-${LINT_VERSION}-linux-amd64.tar.gz | \
-            tar xz --strip-components 1 --wildcards \*/golangci-lint
-          mkdir -p bin && mv golangci-lint bin/
-
-      - name: Run checks
-        run: bin/golangci-lint run --out-format=github-actions
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
+        with:
+          version: v2.11.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,30 @@
+version: "2"
+
 linters:
+  default: standard
   enable:
-    - gofmt
     - godot
     - revive
+  settings:
+    errcheck:
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+    godot:
+      # comments to be checked: `declarations`, `toplevel`, or `all`
+      scope: declarations
+      # check that each sentence starts with a capital letter
+      capital: true
+  exclusions:
+    rules:
+      # The govet `inline` analyzer reports stdlib calls that cannot be inlined
+      # into files using an older Go language version (go.mod is go 1.13).
+      # These are not actionable in user code; suppress them.
+      - linters:
+          - govet
+        text: "^inline: cannot inline call to"
 
-linters-settings:
-  godot:
-    # comments to be checked: `declarations`, `toplevel`, or `all`
-    scope: declarations
-    # check that each sentence starts with a capital letter
-    capital: true
-
-issues:
-  exclude-use-default: false
+formatters:
+  enable:
+    - gofmt

--- a/api/form_test.go
+++ b/api/form_test.go
@@ -117,7 +117,7 @@ type apiClient struct {
 	postCount int
 }
 
-func (c *apiClient) PostForm(u string, params url.Values) (*http.Response, error) {
+func (c *apiClient) PostForm(_ string, _ url.Values) (*http.Response, error) {
 	c.postCount++
 	return &http.Response{
 		Body: ioutil.NopCloser(bytes.NewBufferString(c.body)),

--- a/device/device_flow_test.go
+++ b/device/device_flow_test.go
@@ -313,7 +313,7 @@ func TestPollToken(t *testing.T) {
 
 	singletonFakePoller := func(maxWaits int) pollerFactory {
 		var instance *fakePoller
-		return func(ctx context.Context, interval, expiresIn time.Duration) (context.Context, poller) {
+		return func(ctx context.Context, interval, _ time.Duration) (context.Context, poller) {
 			if instance != nil {
 				// This is to make the factory return the same instance in tests.
 				return ctx, instance


### PR DESCRIPTION
## Description

This repo was super out of date on some of this stuff.

```
➜  oauth git:(wm-bump-golang-ci-lint) golangci-lint run
0 issues.
```